### PR TITLE
Fix link to "Handling compatibility breakages" page

### DIFF
--- a/engine/guidelines/index.rst
+++ b/engine/guidelines/index.rst
@@ -21,4 +21,4 @@ Handling compatibility breakages
 
 .. TODO: Elaborate on types of compatibility and procedure.
 
-See also the `current documentation for compatibility breakages <https://docs.godotengine.org/en/stable/contributing/development/handling_compatibility_breakages.html>`_.
+See also the `current documentation for compatibility breakages <https://docs.godotengine.org/en/stable/engine_details/development/handling_compatibility_breakages.html>`_.


### PR DESCRIPTION
The link to the "Handling compatibility breakages" page was [previously broken](https://docs.godotengine.org/en/stable/contributing/development/handling_compatibility_breakages.html); this PR fixes it to the [current path](https://docs.godotengine.org/en/stable/engine_details/development/handling_compatibility_breakages.html).