### PR TITLE
Fix some links pointing to the `/contributing/` section from the Godot Docs

### DIFF
--- a/engine/unit_tests.rst
+++ b/engine/unit_tests.rst
@@ -8,7 +8,7 @@ Therefore, we expect important logic to be tested with unit tests.
 
 Godot's unit tests are built into the binary, and can be run with an argument to the executable.
 For more information, please read the
-`current documentation for unit tests <https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/unit_testing.html>`_.
+`current documentation for unit tests <https://docs.godotengine.org/en/stable/engine_details/architecture/unit_testing.html>`_.
 
 Unit test guidelines
 --------------------

--- a/other/godot-cpp.rst
+++ b/other/godot-cpp.rst
@@ -23,7 +23,7 @@ Feature guidelines
 
 godot-cpp's API is modeled after Godot's API. We want writing godot-cpp code to be as similar as possible
 to writing a
-`module <https://docs.godotengine.org/en/latest/contributing/development/core_and_modules/custom_modules_in_cpp.html#doc-custom-modules-in-cpp>`__
+`module <https://docs.godotengine.org/en/stable/engine_details/architecture/custom_modules_in_cpp.html#doc-custom-modules-in-cpp>`__
 as possible. This means:
 
 * The frameworks (templates, helper methods, etc.) are synchronized to Godot's frameworks regularly.


### PR DESCRIPTION
This PR fixes a couple links that were pointing to the now-nonexistent `/contributing/` section of https://docs.godotengine.org.