### PR TITLE
Add GitHub meta information: dependabot, pull request template, and CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Properly detect languages on GitHub
+*.rst linguist-detectable=true
+
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!--
+The type of content accepted into the documentation is explained here:
+https://contributing.godotengine.org/en/latest/documentation/contributing_to_the_contributing_docs.html
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # We need to decide on when we upgrade Sphinx manually,
+      # as historically, this has been proven to often imply larger changes
+      # (RTD compat, upgrading extensions, other dependencies, our content, etc.).
+      - dependency-name: "sphinx"

--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -1,0 +1,36 @@
+name: 🌐 Check URLs
+on:
+  schedule:
+    # Every Friday at 16:27 UTC.
+    # URLs can decay over time. Setting up a schedule makes it possible to be warned
+    # about dead links as soon as possible.
+    - cron: "27 16 * * FRI"
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-24.04
+    steps:
+
+      - uses: actions/checkout@v5
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --base .
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --exclude-path _templates/
+            --exclude-path classes/
+            "**/*.md" "**/*.html" "**/*.rst"
+
+      - name: Fail if there were link errors
+        run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Continuous integration
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Style checks via pre-commit
+        uses: pre-commit/action@v3.0.1
+
+      - name: Custom RST checks (check-rst.sh)
+        run: |
+          bash ./_tools/check-rst.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        files: \.(rst|md|py)$
+        additional_dependencies: [tomli]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+        args: ['--fix=lf']

--- a/_tools/check-rst.sh
+++ b/_tools/check-rst.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+output=$(grep -r -P '^(?!\s*\.\.).*\S::$' --include='*.rst' --exclude='docs_writing_guidelines.rst' .)
+if [[ -n $output ]]; then
+  echo 'The shorthand codeblock syntax (trailing `::`) is not allowed.'
+  echo "$output"
+  exit 1
+fi

--- a/_tools/codespell-ignore.txt
+++ b/_tools/codespell-ignore.txt
@@ -1,0 +1,2 @@
+buring
+thirdparty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ build-backend = "flit_core.buildapi"
 name = "Godot Contributing Docs"
 authors = [{name = "Graziella", email = "graziella@lumache"}]
 dynamic = ["version", "description"]
+
+[tool.codespell]
+ignore-words = "_tools/codespell-ignore.txt"


### PR DESCRIPTION
Taken verbatim from https://github.com/godotengine/godot-docs/tree/master/.github (aside from changing the template).

I figured all of those were relevant here as well. The sphinx build CI isn't added yet because it's currently erroring. That can be added in a follow-up PR.