### PR TITLE
Remove link to removed workflow page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -45,7 +45,6 @@ for your topic of interest. You can also use the search function in the top-left
    triage/workflow
    triage/guidelines
    triage/release_blockers
-   triage/team_trackers
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Forgot to remove this when doing my rework recently