### PR TITLE
Add a short section about when pull requests are reviewed.

### DIFF
--- a/organization/pull_requests/review_process.rst
+++ b/organization/pull_requests/review_process.rst
@@ -52,3 +52,21 @@ Even if you are not a maintainer, you can still help by reviewing code,
 providing feedback on PRs and testing PRs locally on your machine to confirm
 that they work as intended. Many of the currently active maintainers started out
 doing this before they became maintainers.
+
+When will a pull request get reviewed?
+--------------------------------------
+
+When you open a new pull request, :ref:`Area maintainers <doc_areas>` are notified immediately.
+
+However, a lot of pull requests are opened every day, so reviews can take a while to come in. Going by historical data,
+you can expect the following review timelines:
+
+- 80% of **regression fixes** are merged (or rejected) within **a week**.
+- 80% of **bug fixes** are merged (or rejected) within **two weeks**.
+- 80% of **enhancements** are merged (or rejected) within **two months**.
+
+As you can imagine, simple pull requests will usually be reviewed more quickly than large and complicated pull requests.
+
+If you think your pull request has been overlooked, feel free to ask about it in the `Contributors' chat <https://chat.godotengine.org>`__.
+You can ask in `#new-contributors <https://chat.godotengine.org/channel/new-contributors>`__, `#devel <https://chat.godotengine.org/channel/devel>`__,
+or the channel of the :ref:`area <doc_areas>` you're expecting reviews from.


### PR DESCRIPTION
This comes up every now and then in the contributor's chat. It's not a huge problem, but it might be nice to be able to refer new contributors here.

I'm basing my claims on the following Kaplan-Meier plot that I created with historical review data from `godotengine/godot`:

<img width="1044" height="450" alt="godot-pr-kaplan-meier" src="https://github.com/user-attachments/assets/ddcbbf31-4816-431f-b839-8d22ec0fd862" />

The code I used to create it is the following. Please be aware that running it takes quite a while, requests fail occasionally, and it requires a custom github token, so I do not recommend doing this. I can provide the data itself on request.

<details>
<summary>kaplan-meier.ipynb</summary>

```python
import requests
import pathlib
import json

data_path = pathlib.Path("./pr-data.json")

if not data_path.exists():
    pull_requests_data = dict()
else:
    pull_requests_data = json.loads(data_path.read_text())

print(len(pull_requests_data))

# Example usage:
owner = 'godotengine'
repo = 'godot'
access_token = '<TOKEN>'  # Optional but recommended for higher rate limits

url = "https://api.github.com/graphql"
headers = {
    "Authorization": f"bearer {access_token}"
}

# First 100 is maximum, but it errors sometimes on that
# See https://github.com/renovatebot/renovate/issues/3862
# Instead, we should use something smaller, to reduce query time.
query = """
    query($owner: String!, $repo: String!, $cursor: String) {
      repository(owner: $owner, name: $repo) {
        pullRequests(first: 50, after: $cursor, states: [OPEN, CLOSED, MERGED]) {
          nodes {
            number
            createdAt
            closedAt
            mergedAt
            labels(first: 10) {
              nodes {
                name
              }
            }
            additions
            deletions
          }
          pageInfo {
            endCursor
            hasNextPage
          }
        }
      }
    }
    """

variables = {
    "owner": owner,
    "repo": repo,
    "cursor": None
}

idx = 0
with requests.Session() as s:
    while True:
        response = s.post(url, json={'query': query, 'variables': variables}, headers=headers)
        response.raise_for_status()
        data = response.json()

        pull_requests = data['data']['repository']['pullRequests']['nodes']
        page_info = data['data']['repository']['pullRequests']['pageInfo']

        for pr in pull_requests:
            pr_number = str(pr['number'])
            del pr['number']
            pull_requests_data[pr_number] = pr

        if not page_info['hasNextPage']:
            break

        # Move to the next page
        variables['cursor'] = page_info['endCursor']
        print(len(pull_requests_data))

        idx += 1
        if idx % 20 == 0:
            print(page_info['endCursor'])

data_path.write_text(json.dumps(pull_requests_data))
print(len(pull_requests_data))
print(max(int(k) for k in pull_requests_data.keys()))
print(min(int(k) for k in pull_requests_data.keys()))
print(page_info['endCursor'])


import pandas as pd
import plotly.express as px
import plotly.graph_objects as go
from datetime import datetime
import numpy as np

def kaplan_meier_from_data(data):
    # Convert to DataFrame
    df = pd.DataFrame([
        {
            'duration': (
                    pd.to_datetime(d['closedAt'] or d['mergedAt']) - pd.to_datetime(d['createdAt'])
            ).days
        }
        for d in data
        if (d['closedAt'] or d['mergedAt'])
    ])

    return pd.Series([(df['duration'] >= i).mean() for i in range(df['duration'].max())])

pull_requests_list = list(pull_requests_data.values())
for d in pull_requests_list:
    d['labels-names'] = set(l['name'] for l in d['labels']['nodes'])

df = pd.DataFrame()
# df['all'] = kaplan_meier_from_data(pull_requests_list)
# ref_2023 = pd.to_datetime('2022-01-01T00:00:00Z')
# df['since 2022'] = kaplan_meier_from_data([d for d in pull_requests_list if pd.to_datetime(d['createdAt']) >= ref_2023])

# df['0-10 changes'] = kaplan_meier_from_data([d for d in pull_requests_list if int(d['additions']) + int(d['deletions']) <= 10])
# df['11-100 changes'] = kaplan_meier_from_data([d for d in pull_requests_list if 10 < (int(d['additions']) + int(d['deletions'])) <= 100])
# df['101-1000 changes'] = kaplan_meier_from_data([d for d in pull_requests_list if 100 < (int(d['additions']) + int(d['deletions'])) <= 1000])
# df['1001+ changes'] = kaplan_meier_from_data([d for d in pull_requests_list if 1000 < (int(d['additions']) + int(d['deletions']))])

df['enhancement'] = kaplan_meier_from_data([d for d in pull_requests_list if 'enhancement' in d['labels-names']])
df['bug'] = kaplan_meier_from_data([d for d in pull_requests_list if 'bug' in d['labels-names']])
df['regression'] = kaplan_meier_from_data([d for d in pull_requests_list if 'regression' in d['labels-names']])
df['documentation'] = kaplan_meier_from_data([d for d in pull_requests_list if 'documentation' in d['labels-names']])
df['codestyle'] = kaplan_meier_from_data([d for d in pull_requests_list if 'topic:codestyle' in d['labels-names']])
```
</summary>