### PR TITLE
Rename `Linux / BSD (X11)` area to `Linux / BSD`.

### DIFF
--- a/organization/areas.rst
+++ b/organization/areas.rst
@@ -256,8 +256,8 @@ Windows / UWP
    :maintainers: <lead>George Marques (@vnen)</lead>, Max Hilbrunner (@mhilbrunner), <lead>Pāvels Nadtočajevs (@bruvzg)</lead>
    :triage_project: <gh-triage project=84>Platforms issue triage</gh-triage>
 
-Linux / BSD (X11)
-~~~~~~~~~~~~~~~~~
+Linux / BSD
+~~~~~~~~~~~
 
 .. gdareatable::
    :communication: #platforms


### PR DESCRIPTION
Linux has Wayland too. IIRC I named the heading, so there should be no problem to change it.