### PR TITLE
Add a section to general guidelines for a thorough pull request description

### DIFF
--- a/organization/general_rules_and_guidelines.rst
+++ b/organization/general_rules_and_guidelines.rst
@@ -35,6 +35,33 @@ This also applies for libraries that are only linked in the editor.
 game engines like Unreal or Unity, nor use their code as inspiration. We strongly recommend against reading any
 "source-available" code before contributing to Godot.
 
+Explain your contributions
+--------------------------
+
+When submitting a pull request, please make use of the pull request description.
+
+Your pull request description should be appropriate for the complexity of the change. For example, if you're just fixing
+a typo, a single sentence description is appropriate. However, if your change is large, or may affect multiple systems
+in potentially unexpected ways, we expect you to be more thorough with your explanation.
+
+Here are the components of a thorough pull request description:
+
+- **Summary of changes:** A short overview of what is changed.
+- **Motivation:** Why you opened the pull request. Ideally, this is a link to an issue or proposal.
+- **Related work:** Link to similar pull requests or ongoing discussions that provide additional context.
+- **Technical overview:** Briefly explain each of the changes in this pull request, and why they are necessary.
+- **Testing:** How you tested the pull request, and the results of your testing. For example, optimization PRs should be
+  profiled or benchmarked (see :ref:`doc_optimization`).
+- **Discussion:** How you see the pull request in context. For example, list risks and caveats and how they could be
+  mitigated. If existing projects may be negatively affected, you should disclose this here, with particular attention
+  to possible :ref:`compatibility breakages <doc_handling_compatibility_breakages>` and regressions.
+- **Additional work:** If applicable, highlight anything you need help with or feedback on, and describe any necessary
+  or potential follow-up work.
+
+.. note:: You may not need *every* one of these components, and you do not need to copy this exact structure.
+          Always ask yourself what would be most helpful for reviewers, and try to balance brevity and thoroughness
+          appropriately.
+
 Contribute only what you understand
 -----------------------------------
 


### PR DESCRIPTION
I often see pull requests with inadequate description.
Some are especially egregious, with only one or two sentences for several hundreds of LOC changed. But even the more thorough ones often lack _some_ component to really make it shine. 

So I think a guideline for a thorough pull request description could be useful. We could link to it any time a contribution lacks a thorough enough description.

The text is inspired by the components of a research paper (abstract, motivation, state of the art, methods, results, discussion, future work). This is a tried-and-true method that's helping researchers connect and describe their complex work.
Of course, contributions to Godot are not research papers, so I adapted the general framework and made it more relevant for us.