### PR TITLE
Use an explicit website title, to avoid the "0.1 documentation" addendum

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,8 @@ html_context = {
 }
 
 html_logo = "img/docs_logo.svg"
+# Set explicitly to avoid the standard title inserting a version.
+html_title = 'Contributing to Godot'
 
 # These folders are copied to the documentation's HTML output
 html_static_path = ["_static"]


### PR DESCRIPTION
Current title:

<img width="295" height="145" alt="SCR-20251211-jsxg" src="https://github.com/user-attachments/assets/1393c89f-401e-4acc-abc8-3404b22f049d" />

New title:

<img width="287" height="139" alt="SCR-20251211-jszt" src="https://github.com/user-attachments/assets/b75a66de-8943-43b8-84cf-98aa0d8ec2c3" />
