### PR TITLE
Change "Maintainers" to "Members". Update the "Members" text and comment.

### DIFF
--- a/_extensions/area_table.py
+++ b/_extensions/area_table.py
@@ -6,7 +6,7 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 import re
 
-area_table_rows = ("Communication", "GitHub reviews", "GitHub labels", "Triage project", "Maintainers")
+area_table_rows = ("Communication", "GitHub reviews", "GitHub labels", "Triage project", "Members")
 
 channel_re = re.compile(r'#([\w-]+)')
 godot_team_re = re.compile(r'@godotengine/([\w-]+)')

--- a/organization/areas.rst
+++ b/organization/areas.rst
@@ -17,24 +17,25 @@ For each team or area there is a list of links and resources associated with the
   For more information about the different GitHub labels, please see the :ref:`doc_bug_triage_guidelines`.
   Note that some GitHub labels aren’t neatly covered by trackers.
 * **Triage project**: links to the team triage project for the team.
-* **Maintainers**: lists the members of each team. The area maintainers take ownership of the area, and will steer its
-  development by creating and reviewing pull requests and improvement proposals. Maintainers are listed alphabetically.
-  Maintainers written as ⭐ **Member** (with a star and in bold) are team leads.
+* **Members**: lists the members of each team alphabetically. Members take ownership of the area, and will steer its
+  development by creating and reviewing pull requests and improvement proposals. In most cases, "Members" is synonymous
+  with "Area maintainers". Members written as ⭐ **Member** (with a star and in bold) are team leads. Please do not
+  contact members directly. Instead, use the linked communication channel of the team.
 
 You can find information about the teams' `current priorities <https://godotengine.org/priorities/>`__ on the Godot website.
 
-.. As a guideline, a team is anything that:
-   - People refer to as a team.
-   - An area that has multiple facets, like a RocketChat channel and a GitHub team.
-
-.. Regarding maintainers:
-   - Generally, the maintainers should correspond to the respective GitHub teams.
-   - "Members" are maintainers here, and "Maintainers" are team leads.
-   - Before adding a maintainer, ask them if they want to be mentioned here.
-   - In particular, ask them how they'd like to be referred to.
+.. Teams are discussed and agreed upon by Godot maintainers. Regarding members:
+   - GitHub serves as the source of truth for team membership. This document should be updated regularly to correspond.
+      Note that the current state of the document is not fully consistent with the GitHub version, as both are outdated
+      in some respects. The differences will hopefully be consolidated over time.
+   - "Team leads" are tagged with "Maintainer" in the corresponding team on GitHub. If they cannot be tagged for
+      technical reasons, they are mentioned in the team comments instead.
+   - Before adding a members, ask them if they want to be mentioned here. In particular, ask them how they'd like to be
+      referred to.
    - If you are a maintainer, you can also open a PR to add yourself, if you are on the respective GitHub team.
 
-.. Html hyperlink targets cannot start with numbers. We're using a trick to override the default generated target: https://stackoverflow.com/a/65284203/503822
+.. Html hyperlink targets cannot start with numbers.
+   We're using a trick to override the default generated target: https://stackoverflow.com/a/65284203/503822
 .. _2d:
 .. _team-2d:
 
@@ -45,7 +46,7 @@ You can find information about the teams' `current priorities <https://godotengi
    :communication: #2d
    :github_reviews: @godotengine/2d-nodes
    :github_labels: <gh-label>topic:2d</gh-label>
-   :maintainers: Gilles Roudière (@groud), Tomasz Chabora (@KoBeWi)
+   :members: Gilles Roudière (@groud), Tomasz Chabora (@KoBeWi)
 
 .. _3d:
 .. _team-3d:
@@ -57,7 +58,7 @@ You can find information about the teams' `current priorities <https://godotengi
    :communication: #devel
    :github_reviews: @godotengine/3d-nodes
    :github_labels: <gh-label>topic:3d</gh-label>
-   :maintainers: Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS)
+   :members: Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS)
 
 Animation
 ---------
@@ -69,7 +70,7 @@ Nodes and features for 2D and 3D animation and IK workflows.
    :github_reviews: @godotengine/animation
    :github_labels: <gh-label>topic:animation</gh-label>
    :triage_project: <gh-triage project=74>Animation issue triage</gh-triage>
-   :maintainers: <lead>Juan Linietsky (@reduz)</lead>, K. S. Ernest Lee (@fire), @Lyuma, @SaracenOne, Silc 'Tokage' Renew (@TokageItLab)
+   :members: <lead>Juan Linietsky (@reduz)</lead>, K. S. Ernest Lee (@fire), @Lyuma, @SaracenOne, Silc 'Tokage' Renew (@TokageItLab)
 
 Audio
 -----
@@ -81,7 +82,7 @@ All audio-related features, from low-level AudioServer and drivers to high-level
    :github_reviews: @godotengine/audio
    :github_labels: <gh-label>topic:audio</gh-label>
    :triage_project: <gh-triage project=101>Audio issue triage</gh-triage>
-   :maintainers: Adam Scott (@adamscott), Ellen Poe (@ellenhp), Juan Linietsky (@reduz)
+   :members: Adam Scott (@adamscott), Ellen Poe (@ellenhp), Juan Linietsky (@reduz)
 
 Buildsystem
 -----------
@@ -93,7 +94,7 @@ Tools and scripts that we use to compile and maintain Godot, both for developmen
    :github_reviews: @godotengine/buildsystem
    :github_labels: <gh-label>topic:buildsystem</gh-label>
    :triage_project: <gh-triage project=53>Buildsystem issue triage</gh-triage>
-   :maintainers: Fabio Alessandrelli (@Faless), HP van Braam (@hpvb), Hugo Locurcio (@Calinou), <lead>Rémi Verschelde (@akien-mga)</lead>, Thaddeus Crews (@Repiteo)
+   :members: Fabio Alessandrelli (@Faless), HP van Braam (@hpvb), Hugo Locurcio (@Calinou), <lead>Rémi Verschelde (@akien-mga)</lead>, Thaddeus Crews (@Repiteo)
 
 Core
 ----
@@ -105,7 +106,7 @@ Low-level Core API: Object, Variant, templates, base nodes like Node, Viewport, 
    :github_reviews: @godotengine/core
    :github_labels: <gh-label>topic:core</gh-label>
    :triage_project: <gh-triage project=95>Core issue triage</gh-triage>
-   :maintainers: George Marques (@vnen), HP van Braam (@hpvb), <lead>Juan Linietsky (@reduz)</lead>, @lawnjelly, Lukas Tenbrink (@Ivorius/@Ivorforce), Rémi Verschelde (@akien-mga)
+   :members: George Marques (@vnen), HP van Braam (@hpvb), <lead>Juan Linietsky (@reduz)</lead>, @lawnjelly, Lukas Tenbrink (@Ivorius/@Ivorforce), Rémi Verschelde (@akien-mga)
 
 Input
 ~~~~~
@@ -114,7 +115,7 @@ Input
    :communication: #input
    :github_reviews: @godotengine/input
    :github_labels: <gh-label>topic:input</gh-label>
-   :maintainers: Rémi Verschelde (@akien-mga), Gilles Roudière (@groud)
+   :members: Rémi Verschelde (@akien-mga), Gilles Roudière (@groud)
 
 Demos
 -----
@@ -122,7 +123,7 @@ Demos
 .. gdareatable::
    :communication: #demo-content
    :github_reviews: @godotengine/demos
-   :maintainers: <lead>Aaron Franke (@aaronfranke)</lead>, Ilaria Cislaghi (@QbieShay), K. S. Ernest Lee (@fire), Rémi Verschelde (@akien-mga)
+   :members: <lead>Aaron Franke (@aaronfranke)</lead>, Ilaria Cislaghi (@QbieShay), K. S. Ernest Lee (@fire), Rémi Verschelde (@akien-mga)
 
 Documentation
 -------------
@@ -135,7 +136,7 @@ for their area.
    :communication: #documentation
    :github_reviews: @godotengine/documentation
    :github_labels: <gh-label>documentation</gh-label>
-   :maintainers: A Thousand Ships (@AThousandShips), Clay John (@clayjohn), Hana - Piralein (@Piralein), Hugo Locurcio (@Calinou), Julian Murgia (@StraToN), <lead>Max Hilbrunner (@mhilbrunner)</lead>, Matthew (@skyace65), Micky (@Mickeon), Raul Santos (@raulsntos)
+   :members: A Thousand Ships (@AThousandShips), Clay John (@clayjohn), Hana - Piralein (@Piralein), Hugo Locurcio (@Calinou), Julian Murgia (@StraToN), <lead>Max Hilbrunner (@mhilbrunner)</lead>, Matthew (@skyace65), Micky (@Mickeon), Raul Santos (@raulsntos)
 
 Editor
 ------
@@ -147,7 +148,7 @@ All things related to the editor, both tools and usability (editor).
    :github_reviews: @godotengine/2d-editor, @godotengine/3d-editor, @godotengine/debugger, @godotengine/docks, @godotengine/script-editor, @godotengine/usability
    :github_labels: <gh-label>topic:editor</gh-label>, <gh-label>topic:export</gh-label>, <gh-label>topic:plugin</gh-label>
    :triage_project: <gh-triage project=111>Editor issue triage</gh-triage>
-   :maintainers: Fabio Alessandrelli (@Faless), George Marques (@vnen), Gilles Roudière (@groud), Hendrik Brucker (@Geometror), Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS), K. S. Ernest Lee (@fire), Kit Bishop (@kitbdev), Michael Alexsander (@YeldhamDev), Paul Batty (@Paulb23), Tomasz Chabora (@KoBeWi)
+   :members: Fabio Alessandrelli (@Faless), George Marques (@vnen), Gilles Roudière (@groud), Hendrik Brucker (@Geometror), Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS), K. S. Ernest Lee (@fire), Kit Bishop (@kitbdev), Michael Alexsander (@YeldhamDev), Paul Batty (@Paulb23), Tomasz Chabora (@KoBeWi)
 
 GUI
 ---
@@ -159,7 +160,7 @@ Everything that inherits Control (everything under ``scene/gui``) and can be use
    :github_reviews: @godotengine/gui-nodes
    :github_labels: <gh-label>topic:gui</gh-label>
    :triage_project: <gh-triage project=100>GUI issue triage</gh-triage>
-   :maintainers: Gilles Roudière (@groud), Hendrik Brucker (@Geometror), Kit Bishop (@kitbdev), Michael Alexsander (@YeldhamDev), Paul Batty (@Paulb23), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga), Tomasz Chabora (@KoBeWi)
+   :members: Gilles Roudière (@groud), Hendrik Brucker (@Geometror), Kit Bishop (@kitbdev), Michael Alexsander (@YeldhamDev), Paul Batty (@Paulb23), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga), Tomasz Chabora (@KoBeWi)
 
 Import
 ------
@@ -171,7 +172,7 @@ Asset import pipeline for 2D (textures) and 3D (scenes, models, animations, etc.
    :github_reviews: @godotengine/import
    :github_labels: <gh-label>topic:import</gh-label>
    :triage_project: <gh-triage project=72>Asset pipeline issue triage</gh-triage>
-   :maintainers: Aaron Franke (@aaronfranke), @BlueCube3310, Gordon MacPherson (@RevoluPowered), Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS), K. S. Ernest Lee (@fire), @Lyuma, Rémi Verschelde (@akien-mga)
+   :members: Aaron Franke (@aaronfranke), @BlueCube3310, Gordon MacPherson (@RevoluPowered), Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS), K. S. Ernest Lee (@fire), @Lyuma, Rémi Verschelde (@akien-mga)
 
 Navigation
 ----------
@@ -192,7 +193,7 @@ Networked multiplayer, RPCs and replication, HTTP/TCP/UDP/DNS, WebSockets, ENet,
    :github_reviews: @godotengine/network
    :github_labels: <gh-label>topic:network</gh-label>, <gh-label>topic:multiplayer</gh-label>
    :triage_project: <gh-triage project=96>Network issue triage</gh-triage>
-   :maintainers: <lead>Fabio Alessandrelli (@Faless)</lead>, Max Hilbrunner (@mhilbrunner)
+   :members: <lead>Fabio Alessandrelli (@Faless)</lead>, Max Hilbrunner (@mhilbrunner)
 
 Physics
 -------
@@ -204,7 +205,7 @@ Physics servers and their implementation in 2D and 3D.
    :github_reviews: @godotengine/physics
    :github_labels: <gh-label>topic:physics</gh-label>
    :triage_project: <gh-triage project=102>Physics issue triage</gh-triage>
-   :maintainers: Fabrice Cipolla (@fabriceci), Juan Linietsky (@reduz), @lawnjelly, Mikael Hermansson (@mihe), Ricardo Buring (@rburing)
+   :members: Fabrice Cipolla (@fabriceci), Juan Linietsky (@reduz), @lawnjelly, Mikael Hermansson (@mihe), Ricardo Buring (@rburing)
 
 Platforms
 ---------
@@ -223,7 +224,7 @@ Android
    :communication: #android
    :github_reviews: @godotengine/android
    :github_labels: <gh-label>platform:android</gh-label>
-   :maintainers: Alexander Hartmann (@Alex2782), Anish (@syntaxerror247), <lead>Fredia Huya-Kouadio (@m4gr3d)</lead>, Rémi Verschelde (@akien-mga)
+   :members: Alexander Hartmann (@Alex2782), Anish (@syntaxerror247), <lead>Fredia Huya-Kouadio (@m4gr3d)</lead>, Rémi Verschelde (@akien-mga)
    :triage_project: <gh-triage project=84>Platforms issue triage</gh-triage>
 
 Apple
@@ -233,7 +234,7 @@ Apple
    :communication: #apple
    :github_reviews: @godotengine/ios, @godotengine/macos
    :github_labels: <gh-label>platform:ios</gh-label>, <gh-label>platform:macos</gh-label>, <gh-label>platform:visionos</gh-label>
-   :maintainers: Bastiaan Olij (@BastiaanOlij), <lead>Pāvels Nadtočajevs (@bruvzg)</lead>
+   :members: Bastiaan Olij (@BastiaanOlij), <lead>Pāvels Nadtočajevs (@bruvzg)</lead>
    :triage_project: <gh-triage project=84>Platforms issue triage</gh-triage>
 
 Web
@@ -243,7 +244,7 @@ Web
    :communication: #web
    :github_reviews: @godotengine/web
    :github_labels: <gh-label>platform:web</gh-label>
-   :maintainers: <lead>Adam Scott (@adamscott)</lead>, Fabio Alessandrelli (@Faless)
+   :members: <lead>Adam Scott (@adamscott)</lead>, Fabio Alessandrelli (@Faless)
    :triage_project: <gh-triage project=84>Platforms issue triage</gh-triage>
 
 Windows / UWP
@@ -253,7 +254,7 @@ Windows / UWP
    :communication: #platforms
    :github_reviews: @godotengine/uwp, @godotengine/windows
    :github_labels: <gh-label>platform:uwp</gh-label>, <gh-label>platform:windows</gh-label>
-   :maintainers: <lead>George Marques (@vnen)</lead>, Max Hilbrunner (@mhilbrunner), <lead>Pāvels Nadtočajevs (@bruvzg)</lead>
+   :members: <lead>George Marques (@vnen)</lead>, Max Hilbrunner (@mhilbrunner), <lead>Pāvels Nadtočajevs (@bruvzg)</lead>
    :triage_project: <gh-triage project=84>Platforms issue triage</gh-triage>
 
 Linux / BSD
@@ -263,7 +264,7 @@ Linux / BSD
    :communication: #platforms
    :github_reviews: @godotengine/linux-bsd
    :github_labels: <gh-label>platform:linuxbsd</gh-label>
-   :maintainers: Dery Almas (@deralmas), Fabio Alessandrelli (@Faless), HP van Braam (@hpvb), Rémi Verschelde (@akien-mga)
+   :members: Dery Almas (@deralmas), Fabio Alessandrelli (@Faless), HP van Braam (@hpvb), Rémi Verschelde (@akien-mga)
    :triage_project: <gh-triage project=84>Platforms issue triage</gh-triage>
 
 Quality Assurance
@@ -285,7 +286,7 @@ for their area.
    :communication: #quality-assurance
    :github_reviews: @godotengine/tests
    :github_labels: <gh-label>topic:tests</gh-label>
-   :maintainers: Hugo Locurcio (@Calinou), Gordon MacPherson (@RevoluPowered), Hendrik Brucker (@Geometror), Rémi Verschelde (@akien-mga)
+   :members: Hugo Locurcio (@Calinou), Gordon MacPherson (@RevoluPowered), Hendrik Brucker (@Geometror), Rémi Verschelde (@akien-mga)
 
 Bugsquad / Issue triage
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -293,7 +294,7 @@ Bugsquad / Issue triage
 .. gdareatable::
    :communication: #bugsquad, #bugsquad-sprints
    :github_reviews: @godotengine/bugsquad
-   :maintainers: <lead>A Thousand Ships (@AThousandShips)</lead>, K. S. Ernest Lee (@fire), @lawnjelly, Rémi Verschelde (@akien-mga)
+   :members: <lead>A Thousand Ships (@AThousandShips)</lead>, K. S. Ernest Lee (@fire), @lawnjelly, Rémi Verschelde (@akien-mga)
 
 Rendering
 ---------
@@ -305,7 +306,7 @@ Rendering server and RenderingDevice implementations (Vulkan, OpenGL), as well a
    :github_reviews: @godotengine/rendering
    :github_labels: <gh-label>topic:rendering</gh-label>
    :triage_project: <gh-triage project=78>Rendering issue triage</gh-triage>
-   :maintainers: Bastiaan Olij (@BastiaanOlij), @BlueCube3310, <lead>Clay John (@clayjohn)</lead>, Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS), Juan Linietsky (@reduz), @lawnjelly, Skyth (Asilkan) (@blueskythlikesclouds), Stuart Carnie (@stuartcarnie)
+   :members: Bastiaan Olij (@BastiaanOlij), @BlueCube3310, <lead>Clay John (@clayjohn)</lead>, Hugo Locurcio (@Calinou), Joan Fons Sanchez (@JFonS), Juan Linietsky (@reduz), @lawnjelly, Skyth (Asilkan) (@blueskythlikesclouds), Stuart Carnie (@stuartcarnie)
 
 Shaders
 ~~~~~~~
@@ -315,7 +316,7 @@ Shaders
    :github_reviews: @godotengine/shaders
    :github_labels: <gh-label>topic:shaders</gh-label>
    :triage_project: <gh-triage project=78>Rendering issue triage</gh-triage>
-   :maintainers: Clay John (@clayjohn), Hendrik Brucker (@Geometror), Ilaria Cislaghi (@QbieShay), Patrick Exner (@paddy-exe), Skyth (Asilkan) (@blueskythlikesclouds), Yuri Rubinsky (@Chaosus)
+   :members: Clay John (@clayjohn), Hendrik Brucker (@Geometror), Ilaria Cislaghi (@QbieShay), Patrick Exner (@paddy-exe), Skyth (Asilkan) (@blueskythlikesclouds), Yuri Rubinsky (@Chaosus)
 
 VFX / Tech Art / Particles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -342,7 +343,7 @@ GDExtension and godot-cpp.
    :github_reviews: @godotengine/gdextension
    :github_labels: <gh-label>topic:gdextension</gh-label>
    :triage_project: <gh-triage project=81>GDExtension issue triage</gh-triage>
-   :maintainers: Bastiaan Olij (@BastiaanOlij), <lead>David Snopek (@dsnopek)</lead>, Fabio Alessandrelli (@Faless), George Marques (@vnen), Gilles Roudière (@groud), Jan Haller (@Bromeon), Juan Linietsky (@reduz), Patrick Exner (@paddy-exe), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga)
+   :members: Bastiaan Olij (@BastiaanOlij), <lead>David Snopek (@dsnopek)</lead>, Fabio Alessandrelli (@Faless), George Marques (@vnen), Gilles Roudière (@groud), Jan Haller (@Bromeon), Juan Linietsky (@reduz), Patrick Exner (@paddy-exe), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga)
 
 GDScript
 ~~~~~~~~
@@ -354,7 +355,7 @@ GDScript language implementation.
    :github_reviews: @godotengine/gdscript
    :github_labels: <gh-label>topic:gdscript</gh-label>
    :triage_project: <gh-triage project=79>GDScript issue triage</gh-triage>
-   :maintainers: Adam Scott (@adamscott), Danil Alexeev (@dalexeev), <lead>George Marques (@vnen)</lead>, @HolonProduction, Yuri Rubinsky (@Chaosus)
+   :members: Adam Scott (@adamscott), Danil Alexeev (@dalexeev), <lead>George Marques (@vnen)</lead>, @HolonProduction, Yuri Rubinsky (@Chaosus)
 
 
 C# / .NET / Mono
@@ -365,7 +366,7 @@ C# / .NET / Mono
    :github_reviews: @godotengine/dotnet
    :github_labels: <gh-label>topic:dotnet</gh-label>
    :triage_project: <gh-triage project=83>Dotnet issue triage</gh-triage>
-   :maintainers: Paul Joannon (@paulloz), <lead>Raul Santos (@raulsntos)</lead>
+   :members: Paul Joannon (@paulloz), <lead>Raul Santos (@raulsntos)</lead>
 
 Technical Leadership Committee (TLC)
 ------------------------------------
@@ -377,7 +378,7 @@ on the Godot website.
 
 .. gdareatable::
    :github_reviews: @godotengine/tlc
-   :maintainers: Bastiaan Olij (@BastiaanOlij), Clay John (@clayjohn), David Snopek (@dsnopek), Fredia Huya-Kouadio (@m4gr3d), George Marques (@vnen), HP van Braam (@hpvb), Juan Linietsky (@reduz), @lawnjelly, Lukas Tenbrink (@Ivorius/@Ivorforce), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga), Tomasz Chabora (@KoBeWi)
+   :members: Bastiaan Olij (@BastiaanOlij), Clay John (@clayjohn), David Snopek (@dsnopek), Fredia Huya-Kouadio (@m4gr3d), George Marques (@vnen), HP van Braam (@hpvb), Juan Linietsky (@reduz), @lawnjelly, Lukas Tenbrink (@Ivorius/@Ivorforce), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga), Tomasz Chabora (@KoBeWi)
 
 Translation / i18n
 ------------------
@@ -398,7 +399,7 @@ Creating the website `godotengine.org <https://godotengine.org>`__ and `asset li
 .. gdareatable::
    :communication: #website, #asset-store
    :github_reviews: @godotengine/website
-   :maintainers: Adam Scott (@adamscott), Emilio Coppola (@coppolaemilio), Hugo Locurcio (@Calinou), Iñigo Allende (@InigoAllende/@i.allende), HP van Braam (@hpvb), Max Hilbrunner (@mhilbrunner), Rémi Verschelde (@akien-mga), <lead>Winston (@winston-yallow)</lead>
+   :members: Adam Scott (@adamscott), Emilio Coppola (@coppolaemilio), Hugo Locurcio (@Calinou), Iñigo Allende (@InigoAllende/@i.allende), HP van Braam (@hpvb), Max Hilbrunner (@mhilbrunner), Rémi Verschelde (@akien-mga), <lead>Winston (@winston-yallow)</lead>
 
 XR
 --
@@ -410,4 +411,4 @@ Augmented (AR) and virtual reality (VR).
    :github_reviews: @godotengine/xr
    :github_labels: <gh-label>topic:xr</gh-label>
    :triage_project: <gh-triage project=104>XR issue triage</gh-triage>
-   :maintainers: <lead>Bastiaan Olij (@BastiaanOlij)</lead>, David Snopek (@dsnopek), Fredia Huya-Kouadio (@m4gr3d), Logan Lang (@devloglogan)
+   :members: <lead>Bastiaan Olij (@BastiaanOlij)</lead>, David Snopek (@dsnopek), Fredia Huya-Kouadio (@m4gr3d), Logan Lang (@devloglogan)


### PR DESCRIPTION
In preparation for the coming update: The "bugsquad" team will get non-maintainer members, so the "Maintainers" description will no longer be accurate.
In addition, we've changed our stance a bit on some details, so I'm updating the text to reflect that.

I'll handle the changed members separately.