### PR TITLE
Reorganize "How to contribute" with new items, rewordings, and more cross-links

### DIFF
--- a/documentation/overview.rst
+++ b/documentation/overview.rst
@@ -1,3 +1,5 @@
+.. _doc_documentation_overview:
+
 Documentation overview
 ======================
 

--- a/organization/how_to_contribute.rst
+++ b/organization/how_to_contribute.rst
@@ -4,9 +4,12 @@ How to contribute
 .. _doc_ways_to_contribute:
 
 The Godot Engine is free and open-source. Like any community-driven project, we rely on volunteer contributions.
+
 On this page we want to showcase the various ways you as users can participate - to help you find the right starting place with the skillset you have.
 Because contrary to popular opinion, we need more than just programmers on the project!
 
+You can also find ways to contribute by browsing the navigation bar on the left.
+If you're on mobile, you may need to click the "navigation icon" on the top left of the page.
 
 Fundraising
 -----------
@@ -31,67 +34,102 @@ Fundraising
 
 .. - **Buy Official Merch**
 
-- **Publish Godot Games.**
-  You heard right, simply publishing a game #MadeWithGodot can positively impact the well-being of this project.
-  Your personal success elevates the engine to a viable alternative for other developers, growing the community further.
-  Additionally, it opens the door for us to approach industry contacts about possible collaborations.
 
-
-Technical contributions
------------------------
+Provide feedback
+----------------
 
 - **Report bugs & other issues**
   As active users of the engine, you are better equipped to identify bugs and other issues than anyone else.
   To let us know about your findings, fill out this `bug report form <https://github.com/godotengine/godot/issues/new/choose>`_ on our GitHub.
   Make sure to include as much information as possible to ensure these issues can easily be reproduced by others.
 
-  If you are interested in helping keep our bug tracker organized, you can even join the `bugsquad <https://chat.godotengine.org/channel/bugsquad>`_!
+- **Propose and discuss ideas**
+  To meaningfully improve Godot, we first need the community to propose and discuss ideas to improve the engine.
+  To get started, please visit our section on :ref:`sharing ideas and proposing changes <doc_contributing_ideas>`.
 
-- **Test Development Versions**
-  While it is recommended to use the stable releases for your projects, you can help us test dev releases, betas, and release candidates
-  by opening a copy of your project in them and checking what problems this introduces or maybe even solves.
-  Make sure to have a backup ready, since this can produce irreversible changes.
+- **Test development versions**
+  While it is recommended to use the stable releases for your projects, you can :ref:`help us test <doc_reporting_issues>`
+  dev releases, betas, and release candidates by opening a copy of your project in them and checking what problems this
+  might introduce or maybe even solves. Make sure to have a backup ready, to avoid potential irreversible changes.
 
   Find recent `development versions <https://godotengine.org/download/preview/>`_ directly on our download page, or linked in their own blog posts.
 
-- **Contribute Engine Code (mainly C++)**
-  The engine development is mainly coordinated on our `Contributor RocketChat <https://chat.godotengine.org/>`_,
-  so if you are serious about making PRs you should join us there!
+- **Test and discuss pull requests**
+  Every change to Godot starts with a pull request, and all pull requests need feedback.
+  Even without knowing how to program, you can help by :ref:`testing whether pull requests work as intended <doc_testing_pull_requests>`,
+  by discussing whether new features are useful and appropriate, and giving feedback on how to improve fixes or new features.
 
-  Read more about the **technical submission process**: :ref:`doc_intro_to_engine_contributions`
+  You can start by browsing pull requests `directly on GitHub <https://github.com/godotengine/godot/pulls>`__,
+  or by finding linked pull requests of `bug reports <https://github.com/godotengine/godot/issues>`__ and of
+  `proposed changes <https://github.com/godotengine/godot-proposals/issues>`__.
 
-  For each subject area of the engine, there is a corresponding team to coordinate the work.
-  Join the linked chat to get more eyes on your related PR, learn about open todos, or partake in meetings.
-  For some areas, specialists might even be encouraged to step up as maintainer!
-  :ref:`List of teams <doc_areas>`
 
-- **Review Code Contributions**
-  All pull requests need to be thoroughly reviewed before they can be merged into the master branch.
-  Help us get a headstart by participating in the code review process.
+Participate in Godot's development
+----------------------------------
 
-  To get started, choose any `open pull request <https://github.com/godotengine/godot/pulls>`_ and reference our **style guide**: :ref:`doc_pr_review_guidelines`
+- **Engine code (mainly C++)**
+  If you are a programmer, you can contribute to Godot by :ref:`working on its source code <doc_intro_to_engine_contributions>`.
+  You can participate in almost every step of the :ref:`PR workflow <doc_pr_workflow>`! Most commonly, contributors
+  fix bugs and make improvements by :ref:`opening pull requests <doc_creating_pull_requests>`.
+  Once you start getting more proficient with Godot's codebase, we'd also greatly appreciate help in the
+  :ref:`code review process <doc_pr_review_guidelines>`!
 
-- **Write Plugins (GDScript, C#, & more)**
+  The engine development is coordinated by :ref:`teams <doc_areas>` and discussed on the `Godot Contributors Chat <https://chat.godotengine.org/>`__.
+  If you are serious about making PRs, you should join us there!
+
+- **Documentation**
+  The documentation is one of the most essential parts of any tech project, yet the need to document new features and substantial changes often gets overlooked.
+  :ref:`Contribute documentation <doc_documentation_overview>` to improve the Godot Engine with your technical writing skills.
+
+- **Translations (spoken languages other than English)**
+  Are you interested in making the Godot Engine more accessible to non-English speakers?
+  Contribute to our :ref:`community translations <doc_editor_and_docs_localization>` on
+  `Weblate <https://hosted.weblate.org/projects/godot-engine/godot/>`__.
+
+- **Bugsquad & triage**
+  With so many bug reports and pull requests being opened each day, the triage team — also called bugsquad — is
+  invaluable to keep things organized.
+  If you'd like to get involved, please visit :ref:`doc_bug_triage_intro`!
+
+- **Contribute to other Godot resources**
+  Besides the engine itself, you can contribute to many other aspects of Godot, such as the :ref:`website <doc_contributing_to_the_website>`,
+  the :ref:`C++ GDExtension bindings <doc_godot_cpp>`, and our :ref:`development resources <doc_resources>`. Many of
+  these non-engine resources are made with different technology from Godot itself, so they require people with
+  different skill sets working on them!
+
+  To find resources to contribute to, browse the navigation bar on the left (on mobile, click the menu button on the top
+  left).
+
+
+Contribute to Godot's ecosystem
+-------------------------------
+
+- **Publish Godot games.**
+  You heard right, simply publishing a game #MadeWithGodot can positively impact the well-being of this project.
+  Your personal success elevates the engine to a viable alternative for other developers, growing the community further.
+  Additionally, it opens the door for us to approach industry contacts about possible collaborations.
+
+- **Create and improve demo projects (GDScript, C#, and making assets)**
+  We provide new users with `demo projects <https://github.com/godotengine/godot-demo-projects/>`_ so they can quickly test new features or get familiar with the engine in the first place.
+  At industry events, we might even exhibit these demo projects to showcase what Godot can do!
+  Help improve existing projects or write your own, and join the `demo channel <https://chat.godotengine.org/channel/demo-content>`_ in the Godot Contributors Chat to talk about it.
+
+- **Write plugins (GDScript, C#, & more)**
   Community addons are not directly included in the core engine download or repository, yet they provide essential quality of life upgrades for your fellow game developers.
   Upload your plugins to the `Godot Asset Library <https://godotengine.org/asset-library/asset>`_ to make them available to others.
 
   ..
     update to talk about Asset Store later
-- **Demo projects (GDScript, C#, and making Assets)**
-  We provide new users with `demo projects <https://github.com/godotengine/godot-demo-projects/>`_ so they can quickly test new features or get familiar with the engine in the first place.
-  At industry events, we might even exhibit these demo projects to showcase what Godot can do!
-  Help improve existing projects or supply your own to be added to the pool, and join the `demo channel <https://chat.godotengine.org/channel/demo-content>`_ in the Contributor RocketChat to talk about it.
 
-- **Documentation**
-  The documentation is one of the most essential parts of any tech project, yet the need to document new features and substantial changes often gets overlooked.
-  Join the `documentation team <https://chat.godotengine.org/channel/documentation>`_ to improve the Godot Engine with your technical writing skills.
+- **Create tutorials & more**
+  How did you get started with the Godot Engine?
+  Chances are you looked for learning materials outside of what the official documentation provides.
+  Without content creators covering the game development process, there would not be this big of a community today.
+  We greatly appreciate every person who makes it their goal to teach others how to use Godot!
 
-- **Translations (spoken languages other than English)**
-  Are you interested in making the Godot Engine more accessible to non-English speakers?
-  Contribute to our `community-translations <https://hosted.weblate.org/projects/godot-engine/godot/>`_.
 
-Community support
------------------
+Help with community support
+---------------------------
 
 - **Call for Moderators**
   With a community of our size, we need people to step up as volunteer moderators in all kinds of places.
@@ -102,9 +140,3 @@ Community support
 - **Answer tech-support questions**
   With many new people discovering the Godot Engine recently, the need for peer-to-peer tech-support has never been greater.
   See the `Godot website <https://godotengine.org/community>`_ for a list of official and user-supported Godot communities.
-
-- **Create tutorials & more**
-  How did you get started with the Godot Engine?
-  Chances are you looked for learning materials outside of what the documentation provides.
-  Without content creators covering the game development process, there would not be this big of a community today.
-  Therefore it seemed only right to mention them in a page about important contributions to the project.

--- a/other/godot-cpp.rst
+++ b/other/godot-cpp.rst
@@ -1,3 +1,5 @@
+.. _doc_godot_cpp:
+
 Contributing to godot-cpp
 =========================
 

--- a/other/website.rst
+++ b/other/website.rst
@@ -1,3 +1,5 @@
+.. _doc_contributing_to_the_website:
+
 Contributing to the website
 ===========================
 


### PR DESCRIPTION
This page is the entry portal for potential new contributors. It's linked directly from the website ("Contributing").

The purpose of this page is not to explain each way to contribute, but to showcase it and make people interested in whatever fits them best. I think it's important for it to be easy to navigate, and focused on what people are coming for.

I've come to improve the focus of the article, make the subsections easier to understand, and to link people towards different places (mostly articles, but also resources) to get them where they need to be for details. 

## Overview of larger changes

**Title case:** We don't use uppercase for titles, so I switched to the usual "sentence case"

**Technical contributions:** I split this section into "Feedback" and "Development" sections. I think contributing as someone with feedback feels very different from being involved with development, especially if you're a newcomer. Getting involved with idea and PR feedback can be a gateway into getting more involved with development in general too, plus we're often lacking healthy discussion on the smaller changes — so I've added those to highlight them and make people aware it's something we're hoping for from the community.

**Contribute to Godot's ecosystem:** This is a new section that's aimed to people who'd rather work on their own, or in small teams, than get involved with the mountain that is Godot' own development. It holds several items that were previously elsewhere.

**Code reviews:** This previously had its own section. I think the people who review Godot's code and those who write Godot's code are the same people — necessarily, because if you don't write code yourself, you're hardly qualified to review it. I therefore merged it into a single "engine contributions" item.

**Bugsquad / Triage:** This did not have an item of its own, just a side note at "report bugs". I think the people who want to report bugs are not (necessarily) the ones who might be interested in joining the bugsquad. Rather, I think people who want to get involved more with Godot development might be drawn to triage. So I gave it its own item in the engine contributions subsection.