### PR TITLE
Add a custom role for team links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ extensions = [
     "sphinxext.opengraph",
     "sphinx_copybutton",
     "sphinxcontrib.video",
-    "area_table",
+    "godot_areas",
     "gdscript",
 ]
 

--- a/documentation/guidelines/content_guidelines.rst
+++ b/documentation/guidelines/content_guidelines.rst
@@ -31,7 +31,7 @@ should ensure that we cover everything Godot does.
 
 .. note::
 
-    When adding or updating an engine feature, the documentation team needs to
+    When adding or updating an engine feature, the :team:`Documentation` needs to
     know about it. Contributors should open an issue on the `godot-docs` repository
     when their work gets merged and requires documentation.
 
@@ -72,7 +72,7 @@ could be considered part of the official API. This means that documenting uninte
 rely on things that might need to be changed in the future, limiting what we can change without breaking compatibility.
 
 To avoid accidentally documenting unintended behavior, :ref:`area maintainers <doc_areas>` should always review
-changes to the documentation of their respective area. The documentation team should help organizing this and with
+changes to the documentation of their respective area. The :team:`Documentation` should help organizing this and with
 writing when needed.
 
 These rules are not absolute, but are usually correct. If you are unsure what to document, don't hesitate to ask the

--- a/organization/areas.rst
+++ b/organization/areas.rst
@@ -124,6 +124,8 @@ Demos
    :github_reviews: @godotengine/demos
    :maintainers: <lead>Aaron Franke (@aaronfranke)</lead>, Ilaria Cislaghi (@QbieShay), K. S. Ernest Lee (@fire), Rémi Verschelde (@akien-mga)
 
+.. _team_documentation:
+
 Documentation
 -------------
 
@@ -286,6 +288,8 @@ for their area.
    :github_reviews: @godotengine/tests
    :github_labels: <gh-label>topic:tests</gh-label>
    :maintainers: Hugo Locurcio (@Calinou), Gordon MacPherson (@RevoluPowered), Hendrik Brucker (@Geometror), Rémi Verschelde (@akien-mga)
+
+.. _team_triage:
 
 Bugsquad / Issue triage
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/organization/how_to_contribute.rst
+++ b/organization/how_to_contribute.rst
@@ -87,7 +87,7 @@ Participate in Godot's development
   `Weblate <https://hosted.weblate.org/projects/godot-engine/godot/>`__.
 
 - **Bugsquad & triage**
-  With so many bug reports and pull requests being opened each day, the triage team — also called bugsquad — is
+  With so many bug reports and pull requests being opened each day, the :team:`Triage` — also called bugsquad — is
   invaluable to keep things organized.
   If you'd like to get involved, please visit :ref:`doc_bug_triage_intro`!
 

--- a/other/triage/guidelines.rst
+++ b/other/triage/guidelines.rst
@@ -3,11 +3,11 @@
 Bug triage guidelines
 =====================
 
-This page describes the typical workflow of the bug triage team aka
+This page describes the typical workflow of the :team:`Triage` aka
 bugsquad when handling issues and pull requests on Godot's
 `GitHub repository <https://github.com/godotengine/godot>`__.
 It is bound to evolve together with the bugsquad, so do not
-hesitate to propose modifications to the following guidelines.
+hesitate to propose modifications to the following guidelines
 
 Issues management
 -----------------

--- a/other/triage/index.rst
+++ b/other/triage/index.rst
@@ -1,7 +1,7 @@
 Bugsquad and triage
 ===================
 
-This section explains the workflow and guidelines of the :ref:`triage team <doc_areas>`.
+This section explains the workflow and guidelines of the :team:`Triage`.
 
 .. toctree::
    :maxdepth: 1

--- a/pull_requests/pr_workflow.rst
+++ b/pull_requests/pr_workflow.rst
@@ -28,7 +28,7 @@ following:
   2. A contributor :ref:`opens a pull request <doc_creating_pull_requests>` that addresses the issue
      or implements the idea.
 
-  3. The :ref:`bugsquad and triage team <doc_areas>` **categorize** the pull request,
+  3. The :team:`Bugsquad and triage team <triage>` **categorize** the pull request,
      adding appropriate tags and requesting reviews from :ref:`area maintainers <doc_areas>`.
 
   4. Contributors discuss **whether the approach of the PR is appropriate** to fix the problem
@@ -52,7 +52,7 @@ this before they became maintainers.
 When will a pull request get reviewed?
 --------------------------------------
 
-When you open a new pull request, :ref:`Area maintainers <doc_areas>` are notified immediately.
+When you open a new pull request, :ref:`area maintainers <doc_areas>` are notified immediately.
 
 However, a lot of pull requests are opened every day, so reviews can take a while to come in. Going by historical data,
 you can expect the following review timelines:


### PR DESCRIPTION
The idea is that we start linking teams across articles.

For example, the GDExtension team should be linked from the "Contributing to godot-cpp" article. 
However, it would be nice if teams were somehow uniformly styled to make them easier to see at a glance. I first considered adding a box to the articles, but found that this would probably be too complicated, and hard to fit into the text.

Instead, I'm adding a simple inline style, much like how team leads are styled with ⭐️ inline:


<img width="433" height="55" alt="SCR-20260128-nofc" src="https://github.com/user-attachments/assets/2d00b7b6-c330-431c-a44f-a814b8b2d78d" />

As a follow-up, we should start linking teams across all pages where they're relevant (e.g. documentation team from documentation guidelines, GDExtension team from godot-cpp guidelines, etc.).