### PR TITLE
Add more team links across the pages.

### DIFF
--- a/documentation/overview.rst
+++ b/documentation/overview.rst
@@ -27,3 +27,6 @@ There are two separate resources referred to as "documentation" in Godot:
   (rst) format, to which you can contribute via pull requests on the
   `godot-docs <https://github.com/godotengine/godot-docs>`_ GitHub repository.
   See :ref:`doc_contributing_to_the_documentation` for more details.
+
+The documentation is managed by the :team:`Documentation`. If you are serious about helping out,
+come join us in the `#documentation <https://chat.godotengine.org/channel/documentation>`__ channel!

--- a/organization/areas.rst
+++ b/organization/areas.rst
@@ -116,6 +116,8 @@ Input
    :github_labels: <gh-label>topic:input</gh-label>
    :maintainers: Rémi Verschelde (@akien-mga), Gilles Roudière (@groud)
 
+.. _team_demos:
+
 Demos
 -----
 
@@ -336,6 +338,8 @@ Scripting
 Umbrella team for all the scripting languages usable with Godot.
 Encompasses some shared core components (Object, ClassDB, MethodBind, ScriptLanguage, etc.) and language specific implementations in dedicated subteams.
 
+.. _team_gdextension:
+
 GDExtension
 ~~~~~~~~~~~
 
@@ -393,6 +397,8 @@ If you work on Godot translations and contributors for your language have a dedi
 .. gdareatable::
    :communication: #translation, #translation-de, #translation-es, #translation-fs, #translation-it
    :github_labels: <gh-label>topic:i18n</gh-label>
+
+.. _team_website:
 
 Website
 -------

--- a/other/benchmarks.rst
+++ b/other/benchmarks.rst
@@ -18,6 +18,9 @@ It's recommended to open one pull request per set of benchmarks. If you create
 multiple benchmarks in unrelated categories, please open separate pull requests
 for each.
 
+If you are serious about helping out, or have anything else to discuss, come join us in the
+`#benchmarks <https://chat.godotengine.org/channel/benchmarks>`__ channel!
+
 Adding new benchmarks
 ---------------------
 

--- a/other/demos.rst
+++ b/other/demos.rst
@@ -4,6 +4,9 @@ Contributing demo projects
 Thanks for your interest in contributing to the
 `Godot demo projects <https://github.com/godotengine/godot-demo-projects>`__!
 
+Demo projects are managed and reviewed by the :team:`Demos`. We greatly appreciate anyone who wants to help out
+or submit new demos!
+
 Demo submission criteria
 ------------------------
 

--- a/other/godot-cpp.rst
+++ b/other/godot-cpp.rst
@@ -9,7 +9,7 @@ Contributing to godot-cpp
     `C++ (godot-cpp) on the Godot docs <https://docs.godotengine.org/en/latest/tutorials/scripting/cpp/index.html>`__
 
 Thank you for your interest in contributing to `godot-cpp <https://github.com/godotengine/godot-cpp>`__,
-the official C++ GDExtension bindings maintained as part of the Godot project!
+the official C++ GDExtension bindings maintained by the :team:`GDExtension`.
 We greatly appreciate help in maintaining and extending this project.
 
 If you wish to help out, ensure you have an account on GitHub and create a "fork" of the

--- a/other/triage_sprints.rst
+++ b/other/triage_sprints.rst
@@ -2,7 +2,7 @@
 
 .. note::
 
-    The bugsquad regularly hosts sprints where anyone can participate, this page contains instructions
+    The :team:`bugsquad <triage>` regularly hosts sprints where anyone can participate, this page contains instructions
     for participating in these, sprints are organized in the
     `#bugsquad-sprints <https://chat.godotengine.org/channel/bugsquad-sprints>`__ channel, subscribe
     to get updates when new sprints are announced.

--- a/other/website.rst
+++ b/other/website.rst
@@ -9,7 +9,8 @@ and maintained with a git repository:
 This includes the static content, informational pages and press material,
 as well as the articles on the blog.
 
-To contribute to it, please use our our regular :ref:`PR workflow <doc_pr_workflow>`.
+To contribute to it, please use our our regular :ref:`PR workflow <doc_pr_workflow>`. Your pull
+requests will be reviewed by the :team:`Website`.
 
 Content guidelines
 ------------------


### PR DESCRIPTION
The idea is for people who want to contribute to find the channels and projects of the teams, so they can help out effectively.

The wording may be a bit awkward here and there since it's stamped on, but I'm sure it'll smoothen out over revisions :)