### PR TITLE
Expand GDScript guidelines with guidelines from the main repository.

### DIFF
--- a/engine/guidelines/gdscript_language_guidelines.rst
+++ b/engine/guidelines/gdscript_language_guidelines.rst
@@ -1,6 +1,37 @@
 GDScript language design guidelines
 ===================================
 
+The :team:`GDScript` aims to avoid over-designing GDScript. Features are added when they
+are needed, and not just because they can be added or are interesting to develop.
+For more information, please refer to :ref:`doc_best_practices_for_engine_contributors`.
+
+Typing guidelines
+-----------------
+
+GDScript is gradually typed. Type hints are optional and help with static analysis and performance.
+However, typed code must easily interoperate with untyped code.
+
+In addition, we expect new typing features to be guaranteed by Godot core. While other
+languages can rely on static typing alone to ensure type correctness, Godot exposes
+lots of ways to interact with the data such that this assumption might fail.
+Therefore, new typing features need to be guaranteed by core in order to be useful to
+GDScript.
+For example, `Array[int]` might be handled by Godot core as `Array` (without typing). That means
+that `Array[int]` must validate newly added elements to be `int`, to avoid non-int elements being
+added in other contexts.
+
+Performance goals
+-----------------
+
+GDScript should be fast enough to be usable for normal gameplay logic.
+
+However, it is more important for GDScript to be easy to use than it is for it to be fast.
+For performance-critical operations, `GDExtension <https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/what_is_gdextension.html>`__
+is a better suited tool.
+
+Performance optimizations to GDScript are welcome as long as they don't jeopardize
+the above goal and are appropriately easy to maintain.
+
 Annotation guidelines
 ---------------------
 

--- a/organization/areas.rst
+++ b/organization/areas.rst
@@ -352,6 +352,8 @@ GDExtension and godot-cpp.
    :triage_project: <gh-triage project=81>GDExtension issue triage</gh-triage>
    :maintainers: Bastiaan Olij (@BastiaanOlij), <lead>David Snopek (@dsnopek)</lead>, Fabio Alessandrelli (@Faless), George Marques (@vnen), Gilles Roudière (@groud), Jan Haller (@Bromeon), Juan Linietsky (@reduz), Patrick Exner (@paddy-exe), Pāvels Nadtočajevs (@bruvzg), Rémi Verschelde (@akien-mga)
 
+.. _team_gdscript:
+
 GDScript
 ~~~~~~~~
 


### PR DESCRIPTION
Migrates some information from the [README.md](https://github.com/godotengine/godot/tree/master/modules/gdscript) on the main godot repository.

I've paraphrased it to fit with guidelines, and added one of my own which often comes up.
I also removed the last point during migration (about language speed). I don't think it makes for a good guideline for a language to be slow 😅

Corresponding engine PR: https://github.com/godotengine/godot/pull/115820/