### PR TITLE
Replace invisible TODO with visible sprint organizer guidance

### DIFF
--- a/other/triage_sprints.rst
+++ b/other/triage_sprints.rst
@@ -7,7 +7,9 @@
     `#bugsquad-sprints <https://chat.godotengine.org/channel/bugsquad-sprints>`__ channel, subscribe
     to get updates when new sprints are announced.
 
-    .. TODO: Add link to instructions for organizing sprints here once written.
+    To organize a sprint, reach out to the :team:`bugsquad <triage>` in the
+    `#bugsquad <https://chat.godotengine.org/channel/bugsquad>`__ channel.
+    Dedicated sprint organizer instructions will be added to this page.
 
 Participating in triage sprints
 ===============================


### PR DESCRIPTION
The TODO on line 10 of `other/triage_sprints.rst` was a reST comment, so it never showed up on the rendered page. Someone interested in organizing a sprint (rather than just participating) would have hit a dead end with no indication that guidance was planned or where to ask for help.

This replaces the invisible comment with a few lines of visible text in the existing note block, pointing organizers to the #bugsquad channel on Rocket.Chat and noting that dedicated organizer instructions are coming. Nothing else in the file changed.

# intro

I'm a technical writer and programmer (close to 20 years in the field, which makes me feel old) poking around the contributing docs for the first time, looking for places to help out as I enjoy writing about game development more than actually playing. Kept this PR small on purpose while I learn the lay of the land.

# ai mention

In compliance with contributing guidelines, I am disclosing that I used Claude to validate which channel was correct (#bugsquad vs. #bugsquad-sprints) and to ensure the compliance of the new text against the writing guidelines--but the final wording is mine.