### PR TITLE
Expand the "Handling compatibility breakages" section

### DIFF
--- a/engine/guidelines/index.rst
+++ b/engine/guidelines/index.rst
@@ -21,6 +21,24 @@ This section explains guidelines for contributing to the engine.
 Handling compatibility breakages
 --------------------------------
 
-.. TODO: Elaborate on types of compatibility and procedure.
+Godot follows a **major.minor.patch** versioning scheme, and each level carries
+different expectations around compatibility:
 
-See also the `current documentation for compatibility breakages <https://docs.godotengine.org/en/stable/engine_details/development/handling_compatibility_breakages.html>`_.
+Maintainers generally control what kind of feature is merged at which part of the dev cycle.
+That being said, you can expect the following kinds of changes to be merged for each version:
+
+- **Patch releases** (e.g. 4.3.1 to 4.3.2) should not break compatibility at all.
+- **Minor releases** (e.g. 4.3 to 4.4) should generally not break compatibility, except to fix bugs. New features are added in backwards-compatible ways.
+- **Major releases** (e.g. 4.x to 5.0) are rare and can include major changes that break compatibility.
+
+If your change adds a parameter to a method, changes a return type, changes the
+type of a parameter, or alters a default value, you need to implement a
+`GDExtension compatibility method <https://docs.godotengine.org/en/stable/engine_details/development/handling_compatibility_breakages.html>`_.
+The CI validation system checks for this automatically, and the pull request
+cannot be merged until it passes.
+
+.. note::
+
+   Reviewers and area maintainers examine PRs with the ``breaks compat`` label
+   more closely, checking whether the breakage is justified and whether the
+   compatibility methods are correctly implemented.


### PR DESCRIPTION
The "Handling compatibility breakages" section in `engine/guidelines/index.rst` had a TODO asking to elaborate on the types of compatibility and procedure. The only other content was a bare link to the external docs page. This meant a contributor landing here got no orientation before being sent elsewhere.

This fills in that section with a brief overview:

- What each release level (patch, minor, major) promises about compatibility
- The distinction between binary and source compatibility
- When and why GDExtension compatibility methods are required
- What the CI validation catches and what the error looks like
- A note about the "breaks compat" label and review expectations

The external docs link is preserved at the bottom for anyone who needs the full technical walkthrough. The section is meant to orient contributors, not replace the external page, so it stays high-level on purpose.