### PR TITLE
Expand the 'ideas and proposals' section

### DIFF
--- a/feedback/ideas.rst
+++ b/feedback/ideas.rst
@@ -8,22 +8,57 @@ is the main driving force behind our decision-making process, and limitations th
 you might face while working on your project are a great data point for us when considering
 engine enhancements.
 
-If you experience a usability problem or are missing a feature in the current version of
-Godot, start by discussing it with our `community <https://godotengine.org/community/>`_.
+If you have an idea, start by sharing and discussing it with our `community <https://godotengine.org/community/>`__.
 There may be other, perhaps better, ways to achieve the desired result that community members
 could suggest. And you can learn if other users experience the same issue, and figure out
 a good solution together.
 
-If you come up with a well-defined idea for the engine, feel free to open a
-`proposal issue <https://github.com/godotengine/godot-proposals/issues>`_.
-Try to be specific and concrete while describing your problem and your proposed
-solution — only actionable proposals can be considered. It is not required, but
-if you want to implement it yourself, that's always appreciated!
+Once you gain a clear understanding of your idea, you can post a proposal.
+Godot keeps track of ideas and proposals in the `godot-proposals repository <https://github.com/godotengine/godot-proposals>`__.
+The `readme file <https://github.com/godotengine/godot-proposals/blob/master/README.md>`__ explains the process
+and has instructions to get started.
 
-If you only have a general idea without specific details, you can open a
-`proposal discussion <https://github.com/godotengine/godot-proposals/discussions>`_.
-These can be anything you want, and allow for a free-form discussion in search of
-a solution. Once you find one, a proposal issue can be opened.
+How are proposals accepted?
+---------------------------
 
-Please, read the `readme <https://github.com/godotengine/godot-proposals/blob/master/README.md>`_
-document before creating a proposal to learn more about the process.
+Proposals are formally accepted by adding them to a :ref:`triage project <doc_triage_projects>`
+and marking them as ``Up for grabs``. You can see if this has happened by looking if a triage
+project is listed on the right of the proposal page, under the word "Projects".
+Maintainers may also make a comment on the proposal to say that the proposal is accepted,
+and in which way it could be implemented.
+
+A proposal being "accepted" means that any contributor (including you!) is free to
+implement the proposed improvement, and submit it as a :ref:`pull request <doc_creating_pull_requests>`.
+However, keep in mind that the proposal being accepted is not a guarantee that a PR will be accepted.
+
+Note that most proposals are not formally accepted before being implemented, especially if they
+are simple. This is usually not a problem, unless the proposal is complex or potentially controversial.
+In this case, we recommend checking in with the responsible :ref:`teams <doc_areas>` before
+starting work to implement something.
+
+Evaluating proposals
+--------------------
+
+There are many ideas and proposals posted to Godot each day, which you can best browse by
+using Godot's `proposal viewer <https://godot-proposals-viewer.github.io>`__.
+
+Many proposals are not ready to be implemented just by the initial proposal alone.
+Each proposal needs an evaluation of whether it is a common problem (through votes and
+interest from the community), and a healthy amount of discussion to assess whether the
+proposed solution is appropriate for the stated problem.
+
+As a knowledgeable Godot user, you can help evaluate proposals by getting involved with the discussion.
+Try to understand the proposal, critically evaluate whether the proposed solution is appropriate,
+and iterate with the author to improve the proposal. Always stay respectful, but remember
+that we have :ref:`guidelines for new features <doc_best_practices_for_engine_contributors>` and
+don't always accept proposals just because they are popular. Factors to take into account when
+evaluating proposals are listed at the bottom of the `readme file <https://github.com/godotengine/godot-proposals/blob/master/README.md#how-we-evaluate-proposals>`__.
+
+If you agree with a problem but think a different solution approach would be more appropriate,
+you can create a new proposal (with reference to the original one). This can be better than
+simply commenting on the original proposal, as it gives the community room to discuss your
+proposal on its own terms.
+
+Proposal **discussions** especially often do not make a specific suggestion for improvement,
+so if you are confident you understand the problem and have an idea for an appropriate solution,
+feel free to open a proposal **issue** to formally propose it (with reference to the **discussion**).


### PR DESCRIPTION
The section is currently lacking in its goal, which should be to document our practices and inform people about ways they can help with the engine.

It also contains some information that's sufficiently covered in the readme (where it's more visible and thus more appropriate, I think), so I removed this information from the article.