### PR TITLE
Document mixed tab/space indentation may be used for multiline wrapping in C++ usage guidelines

### DIFF
--- a/engine/guidelines/cpp_usage_guidelines.rst
+++ b/engine/guidelines/cpp_usage_guidelines.rst
@@ -108,8 +108,11 @@ Naming
 Spacing
 -------
 
-- Indentation and alignment are both tab based (respectively one and two tabs).
-- One space around math and assignments operators as well as after commas.
+- Indentation and alignment are both tab-based (respectively one and two tabs).
+  In some cases, spaces may be used after tab characters to align parameters in
+  long method calls. ``clang-format`` is configured to enforce this, according
+  to how the method call was wrapped over multiple lines.
+- One space around math and assignments operators, as well as after commas.
 - Code is properly spaced (exactly one empty line between methods, no
   unnecessary empty lines inside of method bodies).
 


### PR DESCRIPTION
- See https://github.com/godotengine/godot/pull/117071#issuecomment-4027639453.

One example of this can be found here: https://github.com/godotengine/godot/blob/a1eaac8171a53e5a74cd511bc144bd28afc4c7ff/editor/export/editor_export_platform_apple_embedded.cpp#L2195-L2201
