### PR TITLE
Add supplementary text to Best Practice #6

### DIFF
--- a/engine/guidelines/best_practices.rst
+++ b/engine/guidelines/best_practices.rst
@@ -187,6 +187,18 @@ In real-life scenarios, these use cases will be at most rare and uncommon
 anyway, so it makes sense a custom solution needs to be written. This is why
 it's important to still provide users the basic building blocks to do it.
 
+Overall, our low-level APIs allow us to prioritize pull requests that unblock
+people from creating games.
+
+For example, when users request or implement a new feature, maintainers look at
+the community need, complexity and maintainability of the feature. If it's too
+niché, they might suggest to implement it as an add-on instead, using the
+low-level APIs (if there are any fitting ones, or by adding new ones otherwise).
+
+If an add-on later becomes popular, and authors are still interested to add it to
+Godot, it might be adopted by the maintainers — to give an example, this is what
+happened with the Jolt physics engine.
+
 #7: Prefer local solutions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
In the past, the following text, which was included in the proposal template, has been removed.

```
Is there a reason why this should be core and not an add-on in the asset library?*
```

This was important information regarding the criteria for merging, but according to @Ivorforce, the intention behind removing it was to utilize the proposal as a platform for generating ideas for add-ons.

However, this could lead to situations where reviewers appear to be blocking PRs based on criteria that are not clearly defined in the documentation. This risks exposing reviewers to hostility from PR authors and the community.

Since these merge criteria represent a practical interpretation of `Best Practice #6`, I will leave them there as clearly understandable text.