### PR TITLE
Fix editor style guide  tooltip example for Godot 4

### DIFF
--- a/engine/guidelines/editor_style_guide.rst
+++ b/engine/guidelines/editor_style_guide.rst
@@ -89,7 +89,7 @@ Consider adding tooltips whenever the action performed by a button or menu
 action isn't obvious. You can also provide additional context or highlight
 caveats in the tooltip.
 
-You can do this by calling ``set_tooltip(TTR("Text here."))`` on the
+You can do this by calling ``set_tooltip_text(TTRC("Text here."))`` on the
 Control-based node in question. If the tooltip is particularly long (more than
 ~80 characters), wrap it over several lines by adding line breaks using ``\n``.
 


### PR DESCRIPTION
Updates the Editor Style Guide tooltip example to use `set_tooltip_text()` instead of the removed `set_tooltip()` . 

I'm assuming that this example is for a static case, which is why I used TTRC instead of TTR ([Improving editor's auto-translation #104574](https://github.com/godotengine/godot/issues/104574)) . I can change it if I assumed incorrectly!

Fixes #56 