### PR TITLE
Fix list formatting in Release priority tracking

### DIFF
--- a/other/triage/release_priorities.rst
+++ b/other/triage/release_priorities.rst
@@ -64,10 +64,13 @@ like using certain parts of the engine, or that causes loss of data or work, and
 significant workflow disruption.
 
 Examples of showstopper issues are:
+
 * Parts of the editor or engine that do not work, or are difficult to use, including only on some platforms:
+
     - Changes to the animation system causing errors when using animation features,
     - Improvements to the way the editor generates previews and thumbnails causing severe performance regressions,
     - Changes to the export process causing C# code to not be exported.
+
 * Errors that cause loss of data or work, for example deleting or corrupting project files.
 * Issues using or importing file formats.
 * Issues with specific hardware, like controllers not working or rendering being broken on certain graphics hardware.


### PR DESCRIPTION
rST requires blank lines before the first list item, but also before and after nested lists.

Before | After
-|-
<img width="826" height="358" alt="Image" src="https://github.com/user-attachments/assets/5bcf5773-fef3-4fcb-a978-faea160022f6" /> | <img width="826" height="358" alt="Image" src="https://github.com/user-attachments/assets/cf9fe6ea-584f-4afd-97e0-f5de7ec19a9a" />
