### PR TITLE
Replace references to `pre-commit` with `prek`

### DIFF
--- a/engine/guidelines/cpp_usage_guidelines.rst
+++ b/engine/guidelines/cpp_usage_guidelines.rst
@@ -35,7 +35,7 @@ Automated style checks
 Most of our code style is automatically enforced with formatters (clang-format
 and clang-tidy). If your code does not pass the style checks, the continuous
 integration (CI) on your pull request will fail and your pull request cannot
-be merged. We recommend you :ref:`set up local checks <doc_pre_commit>` to
+be merged. We recommend you :ref:`set up local checks <doc_prek>` to
 save yourself some time.
 
 This article focuses mostly on the parts of our style that are not automatically

--- a/engine/guidelines/other_languages.rst
+++ b/engine/guidelines/other_languages.rst
@@ -17,13 +17,13 @@ Objective-C
 
 Our Objective-c and Objective-c++ code should follow our :ref:`C++ guidelines <doc_cpp_usage_guidelines>`.
 
-Some styles are also automatically enforced using our :ref:`pre-commit hooks <doc_pre_commit>`.
+Some styles are also automatically enforced using our :ref:`prek hooks <doc_prek>`.
 
 Java
 ----
 
 Godot's Java code (mostly in ``platform/android``) is enforced via ``clang-format``.
-It is automatically enforced using our :ref:`pre-commit hooks <doc_pre_commit>`.
+It is automatically enforced using our :ref:`prek hooks <doc_prek>`.
 
 Keep in mind that our style guide only applies to code written and maintained by Godot,
 not third-party code such as the ``java/src/com/google`` subfolder.
@@ -35,6 +35,6 @@ Godot's SCons buildsystem is written in Python, and various scripts included
 in the source tree are also using Python. We use the
 `Ruff linter and code formatter <https://docs.astral.sh/ruff/>`__ to format it.
 
-We recommend you run ruff using our :ref:`pre-commit hooks <doc_pre_commit>`.
+We recommend you run ruff using our :ref:`prek hooks <doc_prek>`.
 
 Alternatively, you can install and run Ruff separately.

--- a/engine/introduction.rst
+++ b/engine/introduction.rst
@@ -94,7 +94,7 @@ By reading this list, you can make a great first impression as a new contributor
   contribution.
 - **Set up local style checks.** The tests will fail on your pull request if
   it does not pass a style check. Save yourself some time and
-  :ref:`set up local style checks <doc_pre_commit>`.
+  :ref:`set up local style checks <doc_prek>`.
 - **Keep it simple.** We :ref:`intentionally avoid <doc_cpp_disallowed_features>`
   using complex C++ features unless necessary. In most cases, avoid using
   clever solutions if a simple solution does the trick.
@@ -106,7 +106,7 @@ For everything else, we have the :ref:`pull request rules <doc_pull_request_guid
 and the :ref:`engine contribution guidelines <doc_engine_guidelines>`.
 To become a proficient contributor, continue reading at your own leisure.
 
-.. _doc_pre_commit:
+.. _doc_prek:
 
 Setting up a dev environment
 ----------------------------
@@ -116,15 +116,15 @@ You can learn how to work with our source code using the `Engine development sec
 Additionally, we recommend you set up style checks locally.
 For example, we use `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`__ and `clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`__
 to format our C++ code.
-The easiest way to set them up is via `pre-commit <https://pre-commit.com/>`__.
+The easiest way to set them up is via `prek <https://prek.j178.dev/>`__.
 
-You can install pre-commit in your local Python installation using pip using the shell code below.
+You can install prek in your local Python installation using pip using the shell code below.
 Depending on your system, there may be other ways to install it which you may prefer.
 
 .. code-block:: shell
 
-    pip install pre-commit
-    pre-commit install
+    pip install prek
+    prek install
 
 IDE integration
 ^^^^^^^^^^^^^^^

--- a/other/godot-cpp.rst
+++ b/other/godot-cpp.rst
@@ -17,7 +17,7 @@ If you wish to help out, ensure you have an account on GitHub and create a "fork
 To contribute, please use our regular :ref:`PR workflow <doc_pr_workflow>`.
 The code should adhere to the same :ref:`code guidelines <doc_engine_guidelines>` as the engine itself.
 
-Please install clang-format and the `pre-commit <https://pre-commit.com/>`__ Python framework so formatting is done
+Please install clang-format and the `prek <https://prek.j178.dev/>`__ pre-commit framework so formatting is done
 before your changes are submitted. See the :ref:`code style guidelines <doc_code_style_guidelines>` for instructions.
 
 Feature guidelines


### PR DESCRIPTION
- See: godotengine/godot#119150

Tweaks the documentation to reference [prek](https://prek.j178.dev/) instead of pre-commit. The latter can still be used at this time, but we should be recommending the significantly faster implementation