### PR TITLE
Add restriction on new features from new contributors

### DIFF
--- a/pull_requests/pull_request_guidelines.rst
+++ b/pull_requests/pull_request_guidelines.rst
@@ -37,6 +37,17 @@ This also applies for libraries that are only linked in the editor.
 game engines like Unreal or Unity, nor use their code as inspiration. We strongly recommend against reading any
 "source-available" code before contributing to Godot.
 
+No features from new contributors
+---------------------------------
+
+Given that the Godot project has grown considerably over the years and that reviewing contributions takes a heavy
+toll on maintainers, while also creating risks for the stability of the existing codebase, we want to ensure that
+new contributors take the time to learn the codebase and engage with maintainers to build trust by working on bug
+fixes and documentation before diving into significant projects.
+
+As a consequence, new features or significant re-factoring from new contributors will not be accepted without explicit
+permission from maintainers in advance. We consider a new contributor to be someone with 3 or fewer merged pull requests.
+
 Contribute one change at a time
 -------------------------------
 

--- a/pull_requests/pull_request_guidelines.rst
+++ b/pull_requests/pull_request_guidelines.rst
@@ -40,8 +40,8 @@ game engines like Unreal or Unity, nor use their code as inspiration. We strongl
 No features from new contributors
 ---------------------------------
 
-Given that the Godot project has grown considerably over the years and that reviewing contributions takes a heavy
-toll on maintainers, while also creating risks for the stability of the existing codebase, we want to ensure that
+The Godot project has grown considerably over the years and reviewing contributions takes a heavy toll on maintainers,
+while also creating risks for the stability of the existing codebase. Given this we want to ensure that
 new contributors take the time to learn the codebase and engage with maintainers to build trust by working on bug
 fixes and documentation before diving into significant projects.
 


### PR DESCRIPTION
Adds the contributor policy from https://godotengine.org/article/contribution-policy-2026/

AI policy to follow in a different PR
