### PR TITLE
Fix stale URLs in godot contributing docs 

### DIFF
--- a/engine/guidelines/gdscript_language_guidelines.rst
+++ b/engine/guidelines/gdscript_language_guidelines.rst
@@ -26,7 +26,7 @@ Performance goals
 GDScript should be fast enough to be usable for normal gameplay logic.
 
 However, it is more important for GDScript to be easy to use than it is for it to be fast.
-For performance-critical operations, `GDExtension <https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/what_is_gdextension.html>`__
+For performance-critical operations, `GDExtension <https://docs.godotengine.org/en/stable/engine_details/engine_api/gdextension/what_is_gdextension.html>`__
 is a better suited tool.
 
 Performance optimizations to GDScript are welcome as long as they don't jeopardize

--- a/engine/guidelines/optimization.rst
+++ b/engine/guidelines/optimization.rst
@@ -28,7 +28,7 @@ reasoning about why a certain chunk of code is slow is often impossible to do
 without detailed metrics (e.g. from a profiler). 
 
 Instructions on using some common profilers with Godot can be found `here
-<https://docs.godotengine.org/en/stable/engine_details/development/debugging/using_cpp_profilers.html>`_.
+<https://docs.godotengine.org/en/stable/engine_details/development/profiling/index.html>`_.
 
 As an example, you may optimize a chunk of code by caching intermediate values.
 However, if that code was slow due to memory constraints, caching the values and

--- a/other/godot-cpp.rst
+++ b/other/godot-cpp.rst
@@ -37,6 +37,6 @@ If you want to make changes to Godot's API, you can use one of two systems:
 * `Core features <https://docs.godotengine.org/en/latest/tutorials/scripting/index.html#core-features>`__: You can add
   new methods and classes to Godot's core features. This exposes the new functionality on godot-cpp as well.
   To get started, please see :ref:`doc_intro_to_engine_contributions`.
-* `GDExtension API <https://docs.godotengine.org/en/latest/tutorials/scripting/gdextension/index.html>`__: You can add
+* `GDExtension API <https://docs.godotengine.org/en/latest/engine_details/engine_api/gdextension/index.html>`__: You can add
   GDExtension lifecycle methods to the GDExtension API itself. We do not have an article for this kind of change as of
   yet.


### PR DESCRIPTION
I have used hyperlinks rather than Sphinx formatting, as the original links were standard URLs. I can update them to :ref: or :doc: if needed.